### PR TITLE
Dev

### DIFF
--- a/inc/background_service.hpp
+++ b/inc/background_service.hpp
@@ -11,9 +11,16 @@ class background_service
         background_service() = default;
         virtual ~background_service() = default;
 
+        /**
+         * Runs service in the background
+         * @returns std::thread that the service is running on
+        */
         virtual std::thread run_background_service() = 0;
 
     protected:
+        /**
+         * Runs service' task
+        */
         virtual void run() = 0;
 };
 

--- a/inc/data_publisher.hpp
+++ b/inc/data_publisher.hpp
@@ -14,23 +14,53 @@
 
 class data_publisher
 {
-    private:
+    public:
+        class converter
+        {
+            public:
+                /**
+                 * @brief Converts detections list into another data format
+                */
+                virtual std::string convert(const std::vector<detection>& results) = 0;
+        };
+
+    protected:
+        std::unique_ptr<converter> data_converter;
         std::shared_ptr<rabbitmq_client> rabbitmq;
         std::string prefix = "detection-results-";
         std::map<unsigned, std::string> declared_exchanges;
 
     public:
         data_publisher(std::shared_ptr<rabbitmq_client> client);
+        data_publisher(std::shared_ptr<rabbitmq_client> client, std::unique_ptr<converter>& data_converter);
         virtual ~data_publisher() = default;
-
-        std::string to_json(const std::vector<detection>& results);
 
         bool publish(unsigned src_id, const std::vector<detection>& results);
         bool publish(unsigned src_id, const std::vector<detection>& results, unsigned limit);
 
     private:
+        /**
+         * @brief Declares exchange in which the client is going to publish
+         * @param src_id source id - creates exchange for this id
+        */
         void declare_exchange(unsigned src_id);
+        /**
+         * @brief Checks wheather this instance already declared exchange for given src_id
+         * @param src_id source id
+        */
         bool is_declared(unsigned src_id);
+};
+
+/**
+ * @brief DATA => JSON Converter
+*/
+class json_converter : data_publisher::converter
+{
+    /**
+     * @brief Converts detections list into JSON data
+     * @returns JSON
+    */
+    virtual std::string convert(const std::vector<detection>& results) override;
 };
 
 #endif // DATA_PUBLISHER_H

--- a/inc/data_publisher.hpp
+++ b/inc/data_publisher.hpp
@@ -18,6 +18,7 @@ class data_publisher
         class converter
         {
             public:
+                virtual ~converter() = default;
                 /**
                  * @brief Converts detections list into another data format
                 */
@@ -54,13 +55,17 @@ class data_publisher
 /**
  * @brief DATA => JSON Converter
 */
-class json_converter : data_publisher::converter
+class json_converter : public data_publisher::converter
 {
-    /**
-     * @brief Converts detections list into JSON data
-     * @returns JSON
-    */
-    virtual std::string convert(const std::vector<detection>& results) override;
+    public:
+        json_converter() = default;
+        virtual ~json_converter() = default;
+
+        /**
+         * @brief Converts detections list into JSON data
+         * @returns JSON
+        */
+        virtual std::string convert(const std::vector<detection>& results) override;
 };
 
 #endif // DATA_PUBLISHER_H

--- a/inc/data_publisher.hpp
+++ b/inc/data_publisher.hpp
@@ -12,6 +12,10 @@
 
 #include "rabbitmq_client.hpp"
 
+/**
+ * @note Join Rabbitmq client before injecting it to the class
+ * @note Do not share rabbitmq client among threads 
+*/
 class data_publisher
 {
     public:

--- a/inc/detection_model.hpp
+++ b/inc/detection_model.hpp
@@ -30,7 +30,14 @@ class detection_model
         std::vector<std::string> classes{};
 
     protected:
+        /**
+         * Loads dnn network model from the path passed in the constructor
+        */
         virtual void load_model() = 0;
+
+        /**
+         * Loads classes (objects labels)
+        */
         virtual void load_classes() = 0;
 
     protected:
@@ -42,14 +49,43 @@ class detection_model
         void operator= (const detection_model&) = delete;
 
     public:
+        /**
+         * @returns name of dnn model (e.g. yolov8.onnx)
+        */
         virtual const std::string_view get_model_name() = 0;
 
+        /**
+         * @returns classes that a model is able to detect
+        */
         virtual auto get_classes() -> const std::vector<std::string>& = 0;
+
+        /**
+         * @returns colors associated with object classes
+        */
         virtual auto get_colors() -> const std::vector<cv::Scalar>& = 0;
 
+        /**
+         * @brief Performs object detection on a given image
+         * @param img The image on which object detection will be performed
+         * @returns list of all detected objects
+        */
         virtual auto object_detection(const cv::Mat& img) -> std::vector<detection> = 0;
+        
+        /**
+         * Performs object detection on a batch of images
+         * @param batch batch of images
+         * @returns list for each image in the batch with detected objects per image
+        */
         virtual auto object_detection_batch(const std::vector<cv::Mat>& batch) -> std::vector<std::vector<detection>> = 0;
         
+        /**
+         * @breif Applies detection results (bounding boxes) directly on a given image.
+         * @param img source image
+         * @param detections list of bounding boxes to apply
+         * @note It will apply the whole detection vector you passed to the function.
+         * @note Filter results before applying them to the image
+         * @returns modified image
+        */
         virtual cv::Mat apply_detections_on_image(const cv::Mat& img, const std::vector<detection>& detections) = 0;
 
     public:

--- a/inc/message_bus_client.hpp
+++ b/inc/message_bus_client.hpp
@@ -18,6 +18,10 @@
 #include <amqpcpp/libboostasio.h>
 
 
+/**
+ * @warning Do not share among threads. Connection and channel are not thread-safe because of the implementation of AMQP-CPP
+ * @note see https://github.com/CopernicaMarketingSoftware/AMQP-CPP/issues/92
+*/
 class message_bus_client
 {
     using client = message_bus_client;

--- a/inc/rabbitmq_client.hpp
+++ b/inc/rabbitmq_client.hpp
@@ -17,6 +17,10 @@ struct source
     std::string exchange;
 };
 
+/**
+ * @warning Do not share among threads. Connection and channel are not thread-safe because of the implementation of AMQP-CPP
+ * @note see https://github.com/CopernicaMarketingSoftware/AMQP-CPP/issues/92
+*/
 class rabbitmq_client : public message_bus_client
 {
     private:

--- a/main.cpp
+++ b/main.cpp
@@ -114,10 +114,17 @@ int main(int argc, const char** argv)
         .bind_available_sources(available_sources_exchange, visitor)
         .bind_obsolete_sources(unregister_sources_exchange, visitor);
 
-    auto publisher = std::make_shared<data_publisher>(rabbitmq);
+    auto rabbitmq_publisher = std::make_shared<rabbitmq_client>(amqp_host);
+
+    #pragma region PUBLISHER
+
+    auto publisher = std::make_shared<data_publisher>(rabbitmq_publisher);
     processing_service::get_service_instance()->set_publishers(publisher, nullptr);
+    
+    #pragma endregion PUBLISHER
 
     rabbitmq->thread_join();
+    rabbitmq_publisher->thread_join();
 
     #pragma endregion RABBITMQ
 

--- a/src/publishers/data_publisher.cpp
+++ b/src/publishers/data_publisher.cpp
@@ -1,8 +1,9 @@
 #include "../../inc/data_publisher.hpp"
 
 data_publisher::data_publisher(std::shared_ptr<rabbitmq_client> client)
-    : rabbitmq(client), data_converter(std::make_unique<converter>(new json_converter()))
+    : rabbitmq(client), data_converter( std::unique_ptr<converter>(new json_converter()) )
 {
+    
 }
 
 data_publisher::data_publisher(std::shared_ptr<rabbitmq_client> client, std::unique_ptr<converter>& custom_converter)


### PR DESCRIPTION
Do not share AMQP clients among threads.
Reason:

> Note that connection and channel objects are not thread safe.
source: https://github.com/CopernicaMarketingSoftware/AMQP-CPP/issues/92